### PR TITLE
Add new section to contribution guide

### DIFF
--- a/CONTRIBUTING-en.md
+++ b/CONTRIBUTING-en.md
@@ -62,13 +62,38 @@ Submitting Changes
 Contribution Tips
 -----------------
 
--  If contributing content to the guide, please make sure that your contribution conforms with [Google's guidelines on writing accessible documentation](https://developers.google.com/style/accessibility) where relevant.
--  If adding a new Markdown file, it may be worth checking out whether it should also appear on the [website version of the guide](https://e-panourgia.github.io/cosmos-tour/). If so, it should be included in the `nav` section of [mkdocs.yml](https://github.com/zkotti/cosmos-tour/blob/main/mkdocs/mkdocs.yml).
+- If contributing content to the guide, please make sure that your contribution conforms with [Google's guidelines on writing accessible documentation](https://developers.google.com/style/accessibility) where relevant.
+- If adding a new Markdown file, it may be worth checking out whether it should also appear on the [website version of the guide](https://e-panourgia.github.io/cosmos-tour/). If so, it should be included in the `nav` section of [mkdocs.yml](https://github.com/zkotti/cosmos-tour/blob/main/mkdocs/mkdocs.yml).
+
+
+##Style pattern
+
+Every coding warehouse nowadays follows a specific pattern of code styling,
+so as to make life of developpers easier and their code prettier. *And so are we.*
+
+####Please take the following advices as kindly suggested:
+#####Conventions
+- Shall use **snake case** formatting for naming **modules** and **files**
+- Shall use **title case** formatting for naming **Classes**
+- Shall use **snake case** formatting for **variables**
+- Shall use **upper case** formatting for **constants**
+- **Code lines** should **not** exceed the length of **100 characters**
+######Note 
+  While style pattern has not been extracted from a specific resource,
+  it could be said that is inspired from PEP8 coding style. 
+  
+#####Additional Suggestions
+Classes should be saparated by two new lines of codes
+Classes should be saparated by one new lines of codes
+Every block of code should not be separated by new line in its core part.
+Comments should exist on separate line from code lines.
+Comments should not be separated with new lines from code lines.
 
 
 Additional Resources
 --------------------
 
--  General GitHub documentation for help <a href="https://docs.github.com/en/" target="_blank">Help</a>
--  GitHub pull request
+- General GitHub documentation for help <a href="https://docs.github.com/en/" target="_blank">Help</a>
+- GitHub pull request
    documentation <a href="https://help.github.com/articles/about-pull-requests/" target="_blank">Pull Request</a>
+- PEP8 official style guide 

--- a/CONTRIBUTING-en.md
+++ b/CONTRIBUTING-en.md
@@ -12,6 +12,28 @@ Getting Started
 -  Make sure you fill in the earliest version that you know has the issue, using commit hashes if possible.
 -  Fork the repository on GitHub.
 
+
+
+##Getting up-to-date 
+It is always a good practice to *update frequently* your local records based on the changes that 
+have been made on the codebase recently.
+
+###How to achieve that?
+* If you are on the **main branch**, you could use ```git pull```.
+* If you are **not on main branch**, you could use:
+   ####*Rebase*
+   You could use the git command: ``git rebase main``
+   <br><br/>
+  _*_Note._*_ If there are conflicts, they need to be resolved, before you move on.
+  This is the only issue that could arise using rebase.
+    ####*Merge*
+   You could use the git command: ``git merge main``
+
+  >>_*Tip:*_<br>Despite the fact that both commands are very useful, it is preferable in projects with many contributors like ours, to use the *rebase* command.
+  <br>Why?<br>
+     *Merge* command creates a new commit each time being used, making *_commit history_* less readable and manageable for maintainability and readability purposes.
+
+
 Making Changes
 --------------
 

--- a/CONTRIBUTING-en.md
+++ b/CONTRIBUTING-en.md
@@ -18,18 +18,18 @@ Getting Started
 
 It is always a good practice to *update frequently* your local records based on the changes that 
 have been made on the codebase recently.
-
 ###How to achieve that?
 
 * If you are on the **main branch**, you could use ```git pull```.
 * If you are **not on main branch**, you could use:
   ####*Rebase*
+
   You could use the git command: ``git rebase main``<\n>
   
-  ######*Note*
+  ######*Note:*
   <p>If there are conflicts, needs to be resolved.
   This is the only issue that could arise using rebase.</p>
-   
+  
   ####*Merge*
    You could use the git command: ``git merge main``
   >>_*Tip:*_<br>Despite the fact that both commands are very useful, it is preferable in projects with many contributors like ours, to use the *rebase* command.
@@ -51,17 +51,20 @@ Making Changes
 -  Follow our `coding style`.
 -  Check again your code to assure nothing else was accidentally broken.
 
+
 Submitting Changes
 ------------------
 
 -  Push your changes to a topic branch in your fork of the repository.
 -  Submit a pull request to the repository.
 
+
 Contribution Tips
 -----------------
 
 -  If contributing content to the guide, please make sure that your contribution conforms with [Google's guidelines on writing accessible documentation](https://developers.google.com/style/accessibility) where relevant.
 -  If adding a new Markdown file, it may be worth checking out whether it should also appear on the [website version of the guide](https://e-panourgia.github.io/cosmos-tour/). If so, it should be included in the `nav` section of [mkdocs.yml](https://github.com/zkotti/cosmos-tour/blob/main/mkdocs/mkdocs.yml).
+
 
 Additional Resources
 --------------------

--- a/CONTRIBUTING-en.md
+++ b/CONTRIBUTING-en.md
@@ -3,6 +3,7 @@ How to contribute
 
 We love pull requests. Here's a quick guide:
 
+
 Getting Started
 ---------------
 
@@ -13,22 +14,24 @@ Getting Started
 -  Fork the repository on GitHub.
 
 
-
 ##Getting up-to-date 
+
 It is always a good practice to *update frequently* your local records based on the changes that 
 have been made on the codebase recently.
 
 ###How to achieve that?
+
 * If you are on the **main branch**, you could use ```git pull```.
 * If you are **not on main branch**, you could use:
-   ####*Rebase*
-   You could use the git command: ``git rebase main``
-   <br><br/>
-  _*_Note._*_ If there are conflicts, they need to be resolved, before you move on.
-  This is the only issue that could arise using rebase.
-    ####*Merge*
+  ####*Rebase*
+  You could use the git command: ``git rebase main``<\n>
+  
+  ######*Note*
+  <p>If there are conflicts, needs to be resolved.
+  This is the only issue that could arise using rebase.</p>
+   
+  ####*Merge*
    You could use the git command: ``git merge main``
-
   >>_*Tip:*_<br>Despite the fact that both commands are very useful, it is preferable in projects with many contributors like ours, to use the *rebase* command.
   <br>Why?<br>
      *Merge* command creates a new commit each time being used, making *_commit history_* less readable and manageable for maintainability and readability purposes.


### PR DESCRIPTION
Restructure an encriche CONTRIBUTING-en.md file.

Refactor the structure of CONTRIBUTING-en.md by separating the sections based on the level of headers being used for them.
Another important part of guide is to ensure contributors working on latest versions of our project to avoid s much conflicts with main branch.
In addition, I considered important to update contributors about some style preferences that we might have. 

New sections added:
-** Getting up-to-date**
-** Style pattern**

